### PR TITLE
Add refactor phase reflection system

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,7 @@ go test ./internal/phase/ -v -run TestNext
 - `internal/session/` — Session persistence (read/write `.tdd-ai.json` in working directory)
 - `internal/phase/` — State machine: `Next()`, `NextWithMode()`, `ExpectedTestResult()`, `CanTransition()`
 - `internal/guide/` — Generates phase-specific instructions and rules based on current phase and mode
+- `internal/reflection/` — Default reflection questions and answer validation for the refactor phase
 - `internal/formatter/` — Formats output as text or JSON (`FormatGuidance`, `FormatStatus`, `FormatFullStatus`)
 
 ### Key Concepts
@@ -42,7 +43,9 @@ go test ./internal/phase/ -v -run TestNext
 - `greenfield` (default) — New code; RED expects tests to fail
 - `retrofit` (`--retrofit`) — Existing code; RED expects tests to pass, skips GREEN
 
-**Session File:** `.tdd-ai.json` in the working directory stores phase, mode, specs, test command, last test result, and event history.
+**Refactor Reflections:** During the refactor phase, 6 structured reflection questions are loaded. Agents must answer all questions (min 5 words each) before advancing. Use `tdd-ai refactor reflect <n> --answer "..."` to answer and `tdd-ai refactor status` to view progress.
+
+**Session File:** `.tdd-ai.json` in the working directory stores phase, mode, specs, test command, last test result, reflections, and event history.
 
 **Output Format:** All commands support `--format json` for machine-readable output. Format auto-detects: JSON when piped, text when in a terminal.
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,12 @@ tdd-ai guide
 # 6. After implementation passes all tests, advance
 tdd-ai phase next --test-result pass
 
-# 7. Refactor, then finish the cycle in one step
+# 7. In refactor phase, answer reflection questions
+tdd-ai refactor status
+tdd-ai refactor reflect 1 --answer "Tests are already descriptive and clear enough"
+# ... answer all 6 questions ...
+
+# 8. Finish the cycle
 tdd-ai complete
 ```
 
@@ -74,6 +79,9 @@ tdd-ai complete
 | `tdd-ai phase set <phase>` | Manually set phase (red/green/refactor/done) |
 | `tdd-ai guide` | Get phase-appropriate instructions |
 | `tdd-ai test` | Run configured test command and record result |
+| `tdd-ai refactor` | Show refactor reflection status |
+| `tdd-ai refactor reflect <n> --answer "..."` | Answer a reflection question |
+| `tdd-ai refactor status` | Show all reflection questions with status |
 | `tdd-ai complete` | Finish TDD cycle (advance to done + mark specs complete) |
 | `tdd-ai status` | Full session overview (phase, mode, specs, next action) |
 | `tdd-ai reset` | Clear session and start over |
@@ -215,6 +223,7 @@ Key rules:
 - In red phase: write tests only, verify they fail, do NOT write implementation
 - In green phase: write minimal implementation, do NOT modify tests
 - In refactor phase: improve code quality, run tests after every change
+- In refactor phase: answer all 6 reflection questions with `tdd-ai refactor reflect`
 - NEVER skip a phase
 ```
 
@@ -358,6 +367,10 @@ Developer: "Implement a rate limiter with sliding window"
                     v
      Agent refactors
      Agent runs: npm test after each change
+     Agent runs: tdd-ai refactor status
+     Agent answers all 6 reflection questions:
+       tdd-ai refactor reflect 1 --answer "Tests clearly describe behavior"
+       ... (all 6 questions) ...
      Agent runs: tdd-ai complete
                     |
                     v

--- a/cmd/commands.go
+++ b/cmd/commands.go
@@ -125,8 +125,9 @@ func workflowSteps() []string {
 		"4. Write code following the instructions",
 		"5. tdd-ai test (run tests and record result)",
 		"6. tdd-ai phase next (advance when phase criteria met)",
-		"7. Repeat steps 3-6 for red -> green -> refactor",
-		"8. tdd-ai complete (finish cycle, mark all specs done)",
+		"7. In refactor: tdd-ai refactor reflect <n> --answer \"...\" (answer all reflection questions)",
+		"8. Repeat steps 3-7 for red -> green -> refactor",
+		"9. tdd-ai complete (finish cycle, mark all specs done)",
 	}
 }
 

--- a/cmd/commands_test.go
+++ b/cmd/commands_test.go
@@ -69,6 +69,7 @@ func TestCommandsIncludesAllCommands(t *testing.T) {
 		"init", "spec add", "spec list", "spec done",
 		"phase", "phase next", "phase set",
 		"guide", "test", "complete", "status", "reset", "version",
+		"refactor", "refactor reflect", "refactor status",
 	}
 
 	commandNames := make(map[string]bool)
@@ -117,8 +118,8 @@ func TestCommandsFlagsPresent(t *testing.T) {
 func TestCommandsWorkflowSteps(t *testing.T) {
 	steps := workflowSteps()
 
-	if len(steps) != 8 {
-		t.Errorf("workflow should have 8 steps, got %d", len(steps))
+	if len(steps) != 9 {
+		t.Errorf("workflow should have 9 steps, got %d", len(steps))
 	}
 
 	if !strings.Contains(steps[0], "init") {
@@ -127,6 +128,17 @@ func TestCommandsWorkflowSteps(t *testing.T) {
 
 	if !strings.Contains(steps[len(steps)-1], "complete") {
 		t.Error("last workflow step should mention complete")
+	}
+
+	foundReflect := false
+	for _, step := range steps {
+		if strings.Contains(step, "refactor reflect") {
+			foundReflect = true
+			break
+		}
+	}
+	if !foundReflect {
+		t.Error("workflow should include refactor reflect step")
 	}
 }
 

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -74,6 +74,12 @@ This is the "I'm done, wrap it up" command.`,
 			return fmt.Errorf("cannot complete: tests are failing. Fix tests before completing the cycle")
 		}
 
+		// Block complete when in refactor with unanswered reflections
+		if s.Phase == types.PhaseRefactor && len(s.Reflections) > 0 && !s.AllReflectionsAnswered() {
+			pending := s.PendingReflections()
+			return fmt.Errorf("cannot complete: %d reflection question(s) unanswered. Use 'tdd-ai refactor status' to see them", len(pending))
+		}
+
 		// Advance through remaining phases to done
 		phasesAdvanced := 0
 		mode := s.GetMode()

--- a/cmd/complete_test.go
+++ b/cmd/complete_test.go
@@ -1,0 +1,111 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/macosta/tdd-ai/internal/reflection"
+	"github.com/macosta/tdd-ai/internal/session"
+	"github.com/macosta/tdd-ai/internal/types"
+)
+
+func executeCompleteCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs(args)
+
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+func TestCompleteBlockedByUnansweredReflections(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRefactor
+	s.AddSpec("feature")
+	s.Reflections = reflection.DefaultQuestions()
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, err := executeCompleteCmd(t, "complete", "--test-result", "pass", "--format", "text")
+	if err == nil {
+		t.Fatal("complete should be blocked when reflections are unanswered")
+	}
+	if !strings.Contains(err.Error(), "reflection question(s) unanswered") {
+		t.Errorf("error should mention unanswered reflections, got: %v", err)
+	}
+}
+
+func TestCompleteWorksWhenAllReflectionsAnswered(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRefactor
+	s.AddSpec("feature")
+	s.Reflections = reflection.DefaultQuestions()
+	for i := range s.Reflections {
+		s.Reflections[i].Answer = "This reflection is answered with enough words"
+	}
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, err := executeCompleteCmd(t, "complete", "--test-result", "pass", "--format", "text")
+	if err != nil {
+		t.Fatalf("complete should work when all reflections answered: %v", err)
+	}
+}
+
+func TestCompleteWorksWithEmptyReflections(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRefactor
+	s.AddSpec("feature")
+	// No reflections (backward compat)
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, err := executeCompleteCmd(t, "complete", "--test-result", "pass", "--format", "text")
+	if err != nil {
+		t.Fatalf("complete should work with empty reflections (backward compat): %v", err)
+	}
+}
+
+func TestCompleteFromRedPhaseNotBlockedByReflections(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRed
+	s.AddSpec("feature")
+	// No reflections loaded yet (they load at refactor entry)
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	// complete from red should advance through all phases without reflection block
+	_, err := executeCompleteCmd(t, "complete", "--test-result", "pass", "--format", "text")
+	if err != nil {
+		t.Fatalf("complete from red should not be blocked by reflections: %v", err)
+	}
+}

--- a/cmd/phase_test.go
+++ b/cmd/phase_test.go
@@ -1,0 +1,178 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/macosta/tdd-ai/internal/reflection"
+	"github.com/macosta/tdd-ai/internal/session"
+	"github.com/macosta/tdd-ai/internal/types"
+)
+
+func executePhaseCmd(t *testing.T, args ...string) (string, string, error) {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs(args)
+
+	err := rootCmd.Execute()
+	return buf.String(), errBuf.String(), err
+}
+
+func TestPhaseNextLoadsReflectionsOnRefactorEntry(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseGreen
+	s.AddSpec("feature")
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, _, err := executePhaseCmd(t, "phase", "next", "--test-result", "pass", "--format", "text")
+	if err != nil {
+		t.Fatalf("phase next failed: %v", err)
+	}
+
+	// Verify reflections were loaded
+	loaded, err := session.Load(dir)
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	if len(loaded.Reflections) != 6 {
+		t.Errorf("should load 6 reflections on refactor entry, got %d", len(loaded.Reflections))
+	}
+	if loaded.Phase != types.PhaseRefactor {
+		t.Errorf("phase should be refactor, got %s", loaded.Phase)
+	}
+}
+
+func TestPhaseNextBlockedByUnansweredReflections(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRefactor
+	s.AddSpec("feature")
+	s.Reflections = reflection.DefaultQuestions()
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, _, err := executePhaseCmd(t, "phase", "next", "--test-result", "pass", "--format", "text")
+	if err == nil {
+		t.Fatal("phase next should be blocked when reflections are unanswered")
+	}
+	if !strings.Contains(err.Error(), "reflection question(s) unanswered") {
+		t.Errorf("error should mention unanswered reflections, got: %v", err)
+	}
+}
+
+func TestPhaseNextFromRefactorWorksWhenAllAnswered(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRefactor
+	s.AddSpec("feature")
+	s.Reflections = reflection.DefaultQuestions()
+	for i := range s.Reflections {
+		s.Reflections[i].Answer = "This reflection is answered with enough words"
+	}
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	out, _, err := executePhaseCmd(t, "phase", "next", "--test-result", "pass", "--format", "text")
+	if err != nil {
+		t.Fatalf("phase next should work when all reflections answered: %v", err)
+	}
+	if !strings.Contains(out, "done") {
+		t.Errorf("should advance to done, got:\n%s", out)
+	}
+}
+
+func TestPhaseNextFromRefactorWorksWithEmptyReflections(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRefactor
+	s.AddSpec("feature")
+	// No reflections (backward compat)
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, _, err := executePhaseCmd(t, "phase", "next", "--test-result", "pass", "--format", "text")
+	if err != nil {
+		t.Fatalf("phase next should work with empty reflections (backward compat): %v", err)
+	}
+}
+
+func TestPhaseSetToRefactorLoadsReflections(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRed
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, _, err := executePhaseCmd(t, "phase", "set", "refactor", "--format", "text")
+	if err != nil {
+		t.Fatalf("phase set refactor failed: %v", err)
+	}
+
+	loaded, err := session.Load(dir)
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	if len(loaded.Reflections) != 6 {
+		t.Errorf("should load 6 reflections when setting to refactor, got %d", len(loaded.Reflections))
+	}
+}
+
+func TestPhaseSetToRefactorDoesNotOverwriteExisting(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRefactor
+	s.Reflections = reflection.DefaultQuestions()
+	s.Reflections[0].Answer = "Already answered this with enough words"
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, _, err := executePhaseCmd(t, "phase", "set", "refactor", "--format", "text")
+	if err != nil {
+		t.Fatalf("phase set refactor failed: %v", err)
+	}
+
+	loaded, err := session.Load(dir)
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	if loaded.Reflections[0].Answer != "Already answered this with enough words" {
+		t.Error("should not overwrite existing reflections")
+	}
+}

--- a/cmd/refactor.go
+++ b/cmd/refactor.go
@@ -1,0 +1,197 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/macosta/tdd-ai/internal/formatter"
+	"github.com/macosta/tdd-ai/internal/reflection"
+	"github.com/macosta/tdd-ai/internal/session"
+	"github.com/macosta/tdd-ai/internal/types"
+	"github.com/spf13/cobra"
+)
+
+var refactorCmd = &cobra.Command{
+	Use:   "refactor",
+	Short: "Show refactor reflection status",
+	Long:  "Show a brief summary of reflection question progress during the refactor phase.",
+	Example: `  tdd-ai refactor
+  tdd-ai refactor status
+  tdd-ai refactor reflect 1 --answer "Tests are already descriptive and clear"`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := getWorkDir()
+		s, err := session.LoadOrFail(dir)
+		if err != nil {
+			return err
+		}
+
+		if s.Phase != types.PhaseRefactor {
+			return fmt.Errorf("not in refactor phase (current: %s)", s.Phase)
+		}
+
+		answered := 0
+		for _, r := range s.Reflections {
+			if r.Answer != "" {
+				answered++
+			}
+		}
+		total := len(s.Reflections)
+
+		if total == 0 {
+			fmt.Fprintln(cmd.OutOrStdout(), "No reflection questions loaded.")
+			return nil
+		}
+
+		fmt.Fprintf(cmd.OutOrStdout(), "Reflections: %d/%d answered\n", answered, total)
+		if answered < total {
+			fmt.Fprintln(cmd.OutOrStdout(), "Run 'tdd-ai refactor status' to see all questions")
+		} else {
+			fmt.Fprintln(cmd.OutOrStdout(), "All reflection questions answered. Ready to advance.")
+		}
+		return nil
+	},
+}
+
+var reflectAnswerFlag string
+
+var reflectCmd = &cobra.Command{
+	Use:   "reflect <question-number>",
+	Short: "Answer a reflection question",
+	Long:  "Answer one of the 6 structured reflection questions required to exit the refactor phase.",
+	Example: `  tdd-ai refactor reflect 1 --answer "Tests are already descriptive and clear enough"
+  tdd-ai refactor reflect 3 --answer "Each test uses its own fixture data"`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := getWorkDir()
+		s, err := session.LoadOrFail(dir)
+		if err != nil {
+			return err
+		}
+
+		if s.Phase != types.PhaseRefactor {
+			return fmt.Errorf("not in refactor phase (current: %s). Reflections are only available during refactor", s.Phase)
+		}
+
+		num, err := strconv.Atoi(args[0])
+		if err != nil {
+			return fmt.Errorf("invalid question number %q: must be an integer", args[0])
+		}
+
+		if reflectAnswerFlag == "" {
+			return fmt.Errorf("--answer is required")
+		}
+
+		if err := reflection.ValidateAnswer(reflectAnswerFlag); err != nil {
+			return err
+		}
+
+		if err := s.AnswerReflection(num, reflectAnswerFlag); err != nil {
+			return err
+		}
+
+		s.AddEvent("reflection_answer", func(e *types.Event) {
+			e.Result = fmt.Sprintf("q%d", num)
+		})
+
+		if err := session.Save(dir, s); err != nil {
+			return err
+		}
+
+		pending := s.PendingReflections()
+		fmt.Fprintf(cmd.OutOrStdout(), "Answered question %d. %d remaining.\n", num, len(pending))
+		return nil
+	},
+}
+
+var refactorStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Show all reflection questions with status",
+	Long:  "Display all 6 reflection questions with their answered/pending status.",
+	Example: `  tdd-ai refactor status
+  tdd-ai refactor status --format json`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		dir := getWorkDir()
+		s, err := session.LoadOrFail(dir)
+		if err != nil {
+			return err
+		}
+
+		if s.Phase != types.PhaseRefactor {
+			return fmt.Errorf("not in refactor phase (current: %s)", s.Phase)
+		}
+
+		f := formatter.Format(formatFlag)
+		switch f {
+		case formatter.FormatJSON:
+			return renderRefactorStatusJSON(cmd, s)
+		case formatter.FormatText:
+			return renderRefactorStatusText(cmd, s)
+		default:
+			return fmt.Errorf("unknown format: %q", f)
+		}
+	},
+}
+
+func renderRefactorStatusJSON(cmd *cobra.Command, s *types.Session) error {
+	type refactorStatusOutput struct {
+		Total       int                        `json:"total"`
+		Answered    int                        `json:"answered"`
+		Pending     int                        `json:"pending"`
+		AllAnswered bool                       `json:"all_answered"`
+		Reflections []types.ReflectionQuestion `json:"reflections"`
+	}
+
+	answered := 0
+	for _, r := range s.Reflections {
+		if r.Answer != "" {
+			answered++
+		}
+	}
+	total := len(s.Reflections)
+
+	out := refactorStatusOutput{
+		Total:       total,
+		Answered:    answered,
+		Pending:     total - answered,
+		AllAnswered: s.AllReflectionsAnswered(),
+		Reflections: s.Reflections,
+	}
+
+	data, err := json.MarshalIndent(out, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encoding refactor status: %w", err)
+	}
+	fmt.Fprintln(cmd.OutOrStdout(), string(data))
+	return nil
+}
+
+func renderRefactorStatusText(cmd *cobra.Command, s *types.Session) error {
+	answered := 0
+	for _, r := range s.Reflections {
+		if r.Answer != "" {
+			answered++
+		}
+	}
+	total := len(s.Reflections)
+
+	fmt.Fprintf(cmd.OutOrStdout(), "Reflections (%d/%d answered):\n\n", answered, total)
+	for _, r := range s.Reflections {
+		status := "pending"
+		if r.Answer != "" {
+			status = "answered"
+		}
+		fmt.Fprintf(cmd.OutOrStdout(), "  [%d] (%s) %s\n", r.ID, status, r.Question)
+		if r.Answer != "" {
+			fmt.Fprintf(cmd.OutOrStdout(), "      -> %q\n", r.Answer)
+		}
+	}
+	return nil
+}
+
+func init() {
+	reflectCmd.Flags().StringVar(&reflectAnswerFlag, "answer", "", "your answer to the reflection question (min 5 words)")
+	refactorCmd.AddCommand(reflectCmd)
+	refactorCmd.AddCommand(refactorStatusCmd)
+	rootCmd.AddCommand(refactorCmd)
+}

--- a/cmd/refactor_test.go
+++ b/cmd/refactor_test.go
@@ -1,0 +1,208 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/macosta/tdd-ai/internal/reflection"
+	"github.com/macosta/tdd-ai/internal/session"
+	"github.com/macosta/tdd-ai/internal/types"
+)
+
+// setupRefactorSession creates a temp directory with a session in refactor phase
+// and reflections loaded. It overrides getWorkDir for the test.
+func setupRefactorSession(t *testing.T) (string, func()) {
+	t.Helper()
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRefactor
+	s.Reflections = reflection.DefaultQuestions()
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	cleanup := func() {
+		os.Chdir(origDir)
+	}
+	return dir, cleanup
+}
+
+func executeRefactorCmd(t *testing.T, args ...string) (string, error) {
+	t.Helper()
+	buf := new(bytes.Buffer)
+	errBuf := new(bytes.Buffer)
+	rootCmd.SetOut(buf)
+	rootCmd.SetErr(errBuf)
+	rootCmd.SetArgs(args)
+
+	err := rootCmd.Execute()
+	return buf.String(), err
+}
+
+func TestRefactorShowsStatus(t *testing.T) {
+	_, cleanup := setupRefactorSession(t)
+	defer cleanup()
+
+	out, err := executeRefactorCmd(t, "refactor", "--format", "text")
+	if err != nil {
+		t.Fatalf("refactor command failed: %v", err)
+	}
+
+	if !strings.Contains(out, "0/6 answered") {
+		t.Errorf("should show 0/6 answered, got:\n%s", out)
+	}
+}
+
+func TestRefactorRejectsWhenNotInRefactorPhase(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseRed
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, err := executeRefactorCmd(t, "refactor", "--format", "text")
+	if err == nil {
+		t.Error("refactor should error when not in refactor phase")
+	}
+}
+
+func TestRefactorReflectSetsAnswer(t *testing.T) {
+	dir, cleanup := setupRefactorSession(t)
+	defer cleanup()
+
+	out, err := executeRefactorCmd(t, "refactor", "reflect", "1", "--answer", "Tests are already descriptive and clear enough", "--format", "text")
+	if err != nil {
+		t.Fatalf("refactor reflect failed: %v", err)
+	}
+
+	if !strings.Contains(out, "Answered question 1") {
+		t.Errorf("should confirm answer, got:\n%s", out)
+	}
+	if !strings.Contains(out, "5 remaining") {
+		t.Errorf("should show remaining count, got:\n%s", out)
+	}
+
+	// Verify session was saved
+	s, err := session.Load(dir)
+	if err != nil {
+		t.Fatalf("failed to load session: %v", err)
+	}
+	if s.Reflections[0].Answer != "Tests are already descriptive and clear enough" {
+		t.Errorf("answer not saved, got %q", s.Reflections[0].Answer)
+	}
+}
+
+func TestRefactorReflectRecordsEvent(t *testing.T) {
+	dir, cleanup := setupRefactorSession(t)
+	defer cleanup()
+
+	_, err := executeRefactorCmd(t, "refactor", "reflect", "1", "--answer", "Tests are already descriptive and clear enough", "--format", "text")
+	if err != nil {
+		t.Fatalf("refactor reflect failed: %v", err)
+	}
+
+	s, _ := session.Load(dir)
+	found := false
+	for _, ev := range s.History {
+		if ev.Action == "reflection_answer" && ev.Result == "q1" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("should record reflection_answer event")
+	}
+}
+
+func TestRefactorReflectRejectsTooFewWords(t *testing.T) {
+	_, cleanup := setupRefactorSession(t)
+	defer cleanup()
+
+	_, err := executeRefactorCmd(t, "refactor", "reflect", "1", "--answer", "no", "--format", "text")
+	if err == nil {
+		t.Error("should reject answer with too few words")
+	}
+	if err != nil && !strings.Contains(err.Error(), "at least 5 words") {
+		t.Errorf("error should mention word count, got: %v", err)
+	}
+}
+
+func TestRefactorReflectErrorsWhenNotInRefactor(t *testing.T) {
+	dir := t.TempDir()
+	s := types.NewSession()
+	s.Phase = types.PhaseGreen
+	if err := session.Save(dir, s); err != nil {
+		t.Fatalf("failed to save session: %v", err)
+	}
+
+	origDir, _ := os.Getwd()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	_, err := executeRefactorCmd(t, "refactor", "reflect", "1", "--answer", "this has more than five words here", "--format", "text")
+	if err == nil {
+		t.Error("should error when not in refactor phase")
+	}
+}
+
+func TestRefactorStatusText(t *testing.T) {
+	dir, cleanup := setupRefactorSession(t)
+	defer cleanup()
+
+	// Answer one question first
+	s, _ := session.Load(dir)
+	s.Reflections[0].Answer = "Tests are already descriptive and clear enough"
+	session.Save(dir, s)
+
+	out, err := executeRefactorCmd(t, "refactor", "status", "--format", "text")
+	if err != nil {
+		t.Fatalf("refactor status failed: %v", err)
+	}
+
+	if !strings.Contains(out, "1/6 answered") {
+		t.Errorf("should show 1/6 answered, got:\n%s", out)
+	}
+	if !strings.Contains(out, "(answered)") {
+		t.Errorf("should show answered label, got:\n%s", out)
+	}
+	if !strings.Contains(out, "(pending)") {
+		t.Errorf("should show pending label, got:\n%s", out)
+	}
+}
+
+func TestRefactorStatusJSON(t *testing.T) {
+	_, cleanup := setupRefactorSession(t)
+	defer cleanup()
+
+	out, err := executeRefactorCmd(t, "refactor", "status", "--format", "json")
+	if err != nil {
+		t.Fatalf("refactor status failed: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+		t.Fatalf("output is not valid JSON: %v\nraw:\n%s", err, out)
+	}
+
+	if parsed["total"] != float64(6) {
+		t.Errorf("total = %v, want 6", parsed["total"])
+	}
+	if parsed["answered"] != float64(0) {
+		t.Errorf("answered = %v, want 0", parsed["answered"])
+	}
+	if parsed["pending"] != float64(6) {
+		t.Errorf("pending = %v, want 6", parsed["pending"])
+	}
+	if parsed["all_answered"] != false {
+		t.Errorf("all_answered = %v, want false", parsed["all_answered"])
+	}
+}

--- a/internal/formatter/formatter.go
+++ b/internal/formatter/formatter.go
@@ -84,6 +84,27 @@ func formatText(g types.Guidance) string {
 		b.WriteString("\n")
 	}
 
+	if len(g.Reflections) > 0 {
+		answered := 0
+		for _, r := range g.Reflections {
+			if r.Answer != "" {
+				answered++
+			}
+		}
+		fmt.Fprintf(&b, "Reflections (%d/%d answered):\n", answered, len(g.Reflections))
+		for _, r := range g.Reflections {
+			status := "pending"
+			if r.Answer != "" {
+				status = "answered"
+			}
+			fmt.Fprintf(&b, "  [%d] (%s) %s\n", r.ID, status, r.Question)
+			if r.Answer != "" {
+				fmt.Fprintf(&b, "      -> %q\n", r.Answer)
+			}
+		}
+		b.WriteString("\n")
+	}
+
 	return b.String()
 }
 

--- a/internal/reflection/reflection.go
+++ b/internal/reflection/reflection.go
@@ -1,0 +1,32 @@
+package reflection
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/macosta/tdd-ai/internal/types"
+)
+
+// MinAnswerWords is the minimum number of words required for a valid reflection answer.
+const MinAnswerWords = 5
+
+// DefaultQuestions returns the 6 structured reflection questions with sequential IDs.
+func DefaultQuestions() []types.ReflectionQuestion {
+	return []types.ReflectionQuestion{
+		{ID: 1, Question: "Can I make my test suite more expressive?"},
+		{ID: 2, Question: "Does my test suite provide reliable feedback?"},
+		{ID: 3, Question: "Are my tests isolated?"},
+		{ID: 4, Question: "Can I reduce duplication in my test suite or implementation code?"},
+		{ID: 5, Question: "Can I make my implementation code more descriptive?"},
+		{ID: 6, Question: "Can I implement something more efficiently?"},
+	}
+}
+
+// ValidateAnswer checks that an answer has at least MinAnswerWords words.
+func ValidateAnswer(answer string) error {
+	words := len(strings.Fields(answer))
+	if words < MinAnswerWords {
+		return fmt.Errorf("answer must be at least %d words, got %d", MinAnswerWords, words)
+	}
+	return nil
+}

--- a/internal/reflection/reflection_test.go
+++ b/internal/reflection/reflection_test.go
@@ -1,0 +1,79 @@
+package reflection
+
+import (
+	"testing"
+)
+
+func TestDefaultQuestionsReturns6(t *testing.T) {
+	questions := DefaultQuestions()
+	if len(questions) != 6 {
+		t.Errorf("DefaultQuestions() returned %d questions, want 6", len(questions))
+	}
+}
+
+func TestDefaultQuestionsSequentialIDs(t *testing.T) {
+	questions := DefaultQuestions()
+	for i, q := range questions {
+		expectedID := i + 1
+		if q.ID != expectedID {
+			t.Errorf("question[%d].ID = %d, want %d", i, q.ID, expectedID)
+		}
+	}
+}
+
+func TestDefaultQuestionsStartUnanswered(t *testing.T) {
+	questions := DefaultQuestions()
+	for _, q := range questions {
+		if q.Answer != "" {
+			t.Errorf("question %d should start unanswered, got %q", q.ID, q.Answer)
+		}
+	}
+}
+
+func TestDefaultQuestionsHaveText(t *testing.T) {
+	questions := DefaultQuestions()
+	for _, q := range questions {
+		if q.Question == "" {
+			t.Errorf("question %d has empty text", q.ID)
+		}
+	}
+}
+
+func TestValidateAnswerRejectsTooFew(t *testing.T) {
+	tests := []struct {
+		name   string
+		answer string
+	}{
+		{"empty", ""},
+		{"one word", "no"},
+		{"two words", "not really"},
+		{"three words", "tests are fine"},
+		{"four words", "tests are all fine"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateAnswer(tt.answer); err == nil {
+				t.Errorf("ValidateAnswer(%q) should return error for <5 words", tt.answer)
+			}
+		})
+	}
+}
+
+func TestValidateAnswerAcceptsEnough(t *testing.T) {
+	tests := []struct {
+		name   string
+		answer string
+	}{
+		{"exactly 5 words", "tests are already very clear"},
+		{"more than 5 words", "I renamed test functions to better describe their behavior"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := ValidateAnswer(tt.answer); err != nil {
+				t.Errorf("ValidateAnswer(%q) returned unexpected error: %v", tt.answer, err)
+			}
+		})
+	}
+}

--- a/npm/README.md
+++ b/npm/README.md
@@ -47,7 +47,12 @@ tdd-ai guide --format json
 # 6. After implementation passes all tests, advance
 tdd-ai phase next --test-result pass
 
-# 7. Refactor, then finish the cycle
+# 7. In refactor phase, answer reflection questions
+tdd-ai refactor status
+tdd-ai refactor reflect 1 --answer "Tests are already descriptive and clear enough"
+# ... answer all 6 questions ...
+
+# 8. Finish the cycle
 tdd-ai complete
 ```
 
@@ -180,6 +185,9 @@ tdd-ai init --retrofit
 | `tdd-ai guide` | Get phase-appropriate instructions |
 | `tdd-ai phase next` | Advance to next phase |
 | `tdd-ai test` | Run configured test command |
+| `tdd-ai refactor` | Show refactor reflection status |
+| `tdd-ai refactor reflect <n> --answer "..."` | Answer a reflection question |
+| `tdd-ai refactor status` | Show all reflection questions with status |
 | `tdd-ai complete` | Finish TDD cycle |
 | `tdd-ai status` | Full session overview |
 


### PR DESCRIPTION
## Summary

- Introduces a **reflection system** that requires AI agents to answer 6 structured questions before exiting the refactor phase, preventing agents from skipping refactoring entirely
- Adds `tdd-ai refactor`, `tdd-ai refactor reflect`, and `tdd-ai refactor status` commands for managing reflections
- Gates `phase next` and `complete` to block advancement from refactor when reflection questions are unanswered

## Problem

AI agents consistently skip the refactor phase — they confirm tests pass and immediately advance to done. The refactor phase had no verification mechanism beyond "tests pass," which is the same check as the green phase. There was no friction and no forced engagement.

## Solution

6 structured reflection questions are automatically loaded when entering the refactor phase:

1. Can I make my test suite more expressive?
2. Does my test suite provide reliable feedback?
3. Are my tests isolated?
4. Can I reduce duplication in my test suite or implementation code?
5. Can I make my implementation code more descriptive?
6. Can I implement something more efficiently?

Each answer must be at least 5 words (enforced by `ValidateAnswer()`). This forces agents to stop and genuinely consider whether refactoring is needed, creating an audit trail of their reasoning.

## Changes

| Area | Files | What changed |
|------|-------|-------------|
| Types | `internal/types/types.go` | `ReflectionQuestion` struct, `Reflections` field on `Session` and `Guidance`, helper methods (`PendingReflections`, `AllReflectionsAnswered`, `AnswerReflection`) |
| Reflection | `internal/reflection/reflection.go` (new) | `DefaultQuestions()`, `ValidateAnswer()`, `MinAnswerWords` constant |
| Phase gates | `cmd/phase.go`, `cmd/complete.go` | Block advancement when reflections unanswered, auto-load on refactor entry |
| Commands | `cmd/refactor.go` (new) | `refactor` (status), `refactor reflect` (answer), `refactor status` (full view) |
| Guidance | `internal/guide/guide.go` | Reflection-aware instructions in refactor phase |
| Formatter | `internal/formatter/formatter.go` | Renders Reflections section in text/JSON output |
| Commands listing | `cmd/commands.go` | Updated workflow steps (now 9) with reflection step |
| Docs | `README.md`, `npm/README.md`, `CLAUDE.md` | New commands, updated Quick Start and agent flow |

## Backward compatibility

Old `.tdd-ai.json` files without a `reflections` field still work — an empty slice means no blocking. The gate logic checks `len(s.Reflections) > 0` before enforcing.

## Test plan

- [x] `make test` — all existing + 30 new tests pass across 7 packages
- [x] `make build` — binary builds cleanly
- [x] `make lint` — no issues
- [ ] Manual walkthrough: init → spec → red → green → refactor (blocked) → answer all → complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)