### PR TITLE
fix: validate binary version before skipping download in install.js

### DIFF
--- a/npm/install.js
+++ b/npm/install.js
@@ -198,8 +198,18 @@ async function main() {
   const ext = platform === "windows" ? ".exe" : "";
   const binaryPath = path.join(binDir, BINARY_NAME + ext);
   if (fs.existsSync(binaryPath)) {
-    console.log(`tdd-ai binary already exists at ${binaryPath}`);
-    return;
+    try {
+      const out = execFileSync(binaryPath, ["version"], { encoding: "utf8" }).trim();
+      // Output format: "tdd-ai X.Y.Z"
+      const installedVersion = out.split(" ").pop();
+      if (installedVersion === version) {
+        console.log(`tdd-ai v${version} already installed at ${binaryPath}`);
+        return;
+      }
+      console.log(`Updating tdd-ai from v${installedVersion} to v${version}...`);
+    } catch {
+      console.log(`Existing binary at ${binaryPath} is invalid, re-downloading...`);
+    }
   }
 
   const url = getDownloadUrl(version, platform, arch);


### PR DESCRIPTION
## Summary

- **Bug:** `npm/install.js` skipped the binary download if *any* file existed at the expected path, regardless of version. This caused stale binaries to persist when upgrading via `npm install -g tdd-ai` without the old package being fully removed.
- **Fix:** Replace the blind `fs.existsSync` early-return with a version-aware check that runs the existing binary (`tdd-ai version`), compares its output to `package.json` version, and only skips the download when they match.
- **Edge case:** If the existing binary is corrupted or non-executable, the `execFileSync` call throws and the catch block triggers a re-download.

## What changed

**`npm/install.js`** (lines 200-213) — replaced:

```js
// Before: skip if ANY binary exists (version-blind)
if (fs.existsSync(binaryPath)) {
  console.log(`tdd-ai binary already exists at ${binaryPath}`);
  return;
}
```

with:

```js
// After: skip only if installed version matches package.json
if (fs.existsSync(binaryPath)) {
  try {
    const out = execFileSync(binaryPath, ["version"], { encoding: "utf8" }).trim();
    const installedVersion = out.split(" ").pop();
    if (installedVersion === version) {
      console.log(`tdd-ai v${version} already installed at ${binaryPath}`);
      return;
    }
    console.log(`Updating tdd-ai from v${installedVersion} to v${version}...`);
  } catch {
    console.log(`Existing binary at ${binaryPath} is invalid, re-downloading...`);
  }
}
```

## Behavior matrix

| Scenario | Before | After |
|---|---|---|
| No binary exists | Downloads | Downloads |
| Binary exists, version matches | Skips (correct) | Skips (correct) |
| Binary exists, version differs | **Skips (bug)** | **Downloads (fixed)** |
| Binary exists but corrupted | **Skips (bug)** | **Downloads (fixed)** |

## Test plan

- [x] `node npm/install.js` with matching binary → prints "already installed", skips download
- [x] `node npm/install.js` with mismatched `package.json` version → prints "Updating from vX to vY", attempts download
- [x] Restore correct version → skips download again

🤖 Generated with [Claude Code](https://claude.com/claude-code)