### PR TITLE
feat: add Claude Code hooks for pre-commit CI and post-PR CI-wait

### DIFF
--- a/.claude/hooks/post-pr-ci-wait.sh
+++ b/.claude/hooks/post-pr-ci-wait.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // ""')
+STDOUT=$(echo "$INPUT" | jq -r '.stdout // ""')
+
+PR_NUMBER=""
+
+# Case 1: gh pr create — PR URL is in stdout
+if [[ "$COMMAND" == *"gh pr create"* ]]; then
+  PR_NUMBER=$(echo "$STDOUT" | grep -oE '/pull/[0-9]+' | grep -oE '[0-9]+' | tail -1)
+fi
+
+# Case 2: git push — check if current branch has an open PR
+if [[ "$COMMAND" == *"git push"* && -z "$PR_NUMBER" ]]; then
+  PR_NUMBER=$(gh pr view --json number -q '.number' 2>/dev/null || true)
+fi
+
+# No PR found — nothing to do
+if [[ -z "$PR_NUMBER" ]]; then
+  exit 0
+fi
+
+echo "Waiting for CI on PR #${PR_NUMBER}..." >&2
+
+# Wait for checks to complete (timeout after 5 minutes)
+if gh pr checks "$PR_NUMBER" --watch --fail-fast 2>/dev/null; then
+  # All checks passed
+  jq -n --arg pr "$PR_NUMBER" '{
+    "systemMessage": ("CI passed on PR #" + $pr + ". All checks green. Report success to the user.")
+  }'
+else
+  # Some check failed — grab the failed run logs
+  FAILED_RUN=$(gh run list --branch "$(git branch --show-current)" --status failure --limit 1 --json databaseId -q '.[0].databaseId' 2>/dev/null || true)
+  LOGS=""
+  if [[ -n "$FAILED_RUN" ]]; then
+    LOGS=$(gh run view "$FAILED_RUN" --log-failed 2>/dev/null | tail -30 || true)
+  fi
+
+  jq -n --arg pr "$PR_NUMBER" --arg logs "$LOGS" '{
+    "systemMessage": ("CI FAILED on PR #" + $pr + ". Investigate the failure, fix if possible, or report to the user. Failed logs:\n" + $logs)
+  }'
+fi

--- a/.claude/hooks/pre-commit-ci.sh
+++ b/.claude/hooks/pre-commit-ci.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+COMMAND=$(jq -r '.tool_input.command // ""')
+
+# Fast path: only gate git commit commands
+if [[ "$COMMAND" != *"git commit"* && "$COMMAND" != *"git -C"*"commit"* ]]; then
+  exit 0
+fi
+
+echo "Pre-commit hook: running gofmt and make ci..." >&2
+
+gofmt -w .
+
+if ! make ci 2>&1; then
+  echo "BLOCKED: make ci failed. Fix the issues above before committing." >&2
+  exit 2
+fi
+
+echo "Pre-commit hook: all checks passed." >&2
+exit 0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -30,6 +30,16 @@ Before committing or pushing code, ALWAYS run:
 
 Do NOT commit or push if `make ci` fails. Fix issues first.
 
+## Automated Hooks
+
+Two Claude Code hooks enforce quality gates automatically:
+
+1. **Pre-commit hook** (`.claude/hooks/pre-commit-ci.sh`): Runs `gofmt -w .` and `make ci` before every `git commit`. Blocks the commit if CI fails.
+
+2. **Post-PR CI-wait hook** (`.claude/hooks/post-pr-ci-wait.sh`): After `gh pr create` or `git push` to a PR branch, waits for GitHub Actions CI to complete. Reports the result back — on failure, investigate and fix or report to the user.
+
+These hooks are registered in `.claude/settings.local.json` and run automatically.
+
 ## Architecture
 
 **tdd-ai** is a Go CLI tool that enforces TDD discipline for AI coding agents. It does NOT run tests itself — the AI agent runs tests using whatever framework the project uses. The tool provides a state machine, phase-appropriate guidance, and structured output.


### PR DESCRIPTION
## Summary

- **Pre-commit hook** (`.claude/hooks/pre-commit-ci.sh`): Intercepts `git commit` commands via a `PreToolUse` hook, runs `gofmt -w .` and `make ci`, and blocks the commit (exit 2) if CI fails. Non-commit commands exit immediately with no delay.
- **Post-PR CI-wait hook** (`.claude/hooks/post-pr-ci-wait.sh`): Fires after `gh pr create` or `git push` to a PR branch via a `PostToolUse` hook, waits for GitHub Actions CI via `gh pr checks --watch`, and reports the result back as a `systemMessage` so Claude is automatically notified of pass/fail.
- **CLAUDE.md** updated with an "Automated Hooks" section documenting both hooks.

Both hooks are registered in `.claude/settings.local.json` (not committed — contains machine-specific paths). After cloning, users need to add the `hooks` config to their own `settings.local.json`.

### Motivation

A transient CI failure (golangci-lint network timeout) on PR #6 went unnoticed until the user checked manually. These hooks close two gaps:
1. Nothing enforced running `make ci` before committing, despite CLAUDE.md saying to.
2. After creating a PR, Claude didn't wait to see if CI passed.

## Test plan

- [ ] Run a non-commit command (e.g. `git status`) — verify no delay from the pre-commit hook
- [ ] Temporarily break a Go file, attempt to commit — verify the hook blocks with `make ci` failure
- [ ] Fix the file, commit again — verify the hook passes and commit succeeds
- [ ] Create a PR — verify the post-PR hook waits for `gh pr checks --watch` and reports the result
- [ ] Push to an existing PR branch — verify the same CI-wait behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)